### PR TITLE
Fix for pyshellclient path

### DIFF
--- a/pyshellclient.js
+++ b/pyshellclient.js
@@ -11,7 +11,7 @@
  */
 
 if ((!global.CONSTANTS) && (!process.env.MONKSHU_HOME)) {console.error("\nError: MONKSHU_HOME not set.\n"); process.exit(1);}
-const MONKSHULIBDIR = global.CONSTANTS ? CONSTANTS.LIBDIR : process.env.MONKSHU_HOME+"/backend/server/lib";
+const MONKSHULIBDIR = global.CONSTANTS ? (CONSTANTS.MONKSHU_HOME ? CONSTANTS.MONKSHU_HOME+"/backend/server/lib" : CONSTANTS.LIBDIR) : process.env.MONKSHU_HOME+"/backend/server/lib";
 
 const fs = require("fs");
 const path = require("path");


### PR DESCRIPTION
The following line:

`const MONKSHULIBDIR = global.CONSTANTS ? CONSTANTS.LIBDIR : process.env.MONKSHU_HOME + "/backend/server/lib";`

resolves to the local project’s lib directory (e.g., MONBOSS/lib) due to the global.CONSTANTS check. This leads to incorrect behavior when the script runs outside Monkshu.

- We have added CONSTANTS.MONKSHU_HOME to ensure the library path always points to Monkshu’s directory, if that’s not available, it falls back to CONSTANTS.LIBDIR so that it can be invoked from external application eg. Kloudust.