### PR TITLE
[FIX] fix for pyshell redeployment

### DIFF
--- a/deploy/remotedeploy.sh
+++ b/deploy/remotedeploy.sh
@@ -78,9 +78,16 @@ if [[ "${PYSHELL_FIREWALL,,}" != "false" ]]; then
     done
         
     if ! sudo nft add rule inet "$NFT_TABLE" input tcp dport "$PYSHELL_PORT" accept; then exitFailed "Firewall port opening error"; fi
-    if ! sudo nft list ruleset | sudo tee /etc/nftables.conf; then exitFailed "Firewall save rules error"; fi
+
+    ## Persist the rules to disk so they survive reboots
+    if ! sudo mkdir -p /etc/nftables.d; then exitFailed "Firewall dropin dir creation error"; fi
+    sudo tee /etc/nftables.conf > /dev/null <<'EOF'
+#!/usr/sbin/nft -f
+include "/etc/nftables.d/*.nft"
+EOF
+    if [ $? -ne 0 ]; then exitFailed "Firewall conf write error"; fi
+    if ! { echo "table inet $NFT_TABLE"; echo "delete table inet $NFT_TABLE"; sudo nft list table inet "$NFT_TABLE"; } | sudo tee "/etc/nftables.d/$NFT_TABLE.nft" > /dev/null; then exitFailed "Firewall save rules error"; fi
     if ! sudo systemctl enable --now nftables; then exitFailed "Firewall service enable error"; fi
-    if ! sudo systemctl restart nftables; then exitFailed "Firewall reload error"; fi
 fi
 
 sudo systemctl daemon-reload

--- a/test_host.sh
+++ b/test_host.sh
@@ -205,7 +205,14 @@ if ! sudo nft add rule inet kdhostfirewall input tcp dport $NEW_SSH_PORT accept;
 if ! sudo nft add rule inet kdhostfirewall input tcp dport $AGENT_PORT accept; then exitFailed; fi          #Agent port
 if ! sudo nft rule inet kdhostfirewall input udp dport 8472 accept; then exitFailed; fi   # VxLAN port
 if ! sudo nft chain inet kdhostfirewall input { policy drop\; }; then exitFailed; fi
-if ! sudo nft list ruleset > /etc/nftables.conf; then exitFailed; fi 
+
+if ! sudo mkdir -p /etc/nftables.d; then exitFailed; fi
+sudo tee /etc/nftables.conf > /dev/null <<'EOF'
+#!/usr/sbin/nft -f
+include "/etc/nftables.d/*.nft"
+EOF
+if [ $? -ne 0 ]; then exitFailed; fi
+if ! { echo "table inet kdhostfirewall"; echo "delete table inet kdhostfirewall"; sudo nft list table inet kdhostfirewall; } | sudo tee /etc/nftables.d/kdhostfirewall.nft > /dev/null; then exitFailed; fi
 if ! sudo systemctl enable nftables; then exitFailed; fi                                  # Reboot will enforce the firewall
 # Setup IP forwarding and ARP forwarding support
 if ! echo 1 | sudo tee /proc/sys/net/ipv4/ip_forward > /dev/null; then exitFailed; fi   


### PR DESCRIPTION
**Changes made:**
- Switched firewall persistence from full ruleset dump to nftables drop-in config (/etc/nftables.d/*.nft) with per-table idempotent files
- Removed systemctl restart nftables after deploy

**Why the changes were made:**
- Old approach duplicated rules and captured unrelated tables on every redeploy; restarting nftables flushed live runtime state